### PR TITLE
Updating copyright year to be a dynamic value

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,7 @@
           <span class="icon"><i class="fa fa-heart" style="color:#ff4d44"></i></span> with <br>
           <!--<a target='_blank' href="//laravel.com"><img src="/static/images/laravel-icon.png"></a>-->
           <a target='_blank' href="//vuejs.org"><img src="/static/images/vue-icon.png"></a>.</p>
-        <p>Copyright &copy; 2017 <a target='_blank' href="//github.com/ashishpatel0720">@ashishpatel0720</a></p>
+        <p>Copyright &copy; {{ new Date().getFullYear() }} <a target='_blank' href="//github.com/ashishpatel0720">@ashishpatel0720</a></p>
       </div>
     </header>
     <div class="wrapper">


### PR DESCRIPTION
## Change
Updating copyright year to dynamic value according to present date  value.

**Previous experience**
Copyright year value is hard-coded, hence does not automatically gets updated on year change

**Updated experience**
Copyright year value is generated dynamically as per current date, hence automatically gets updated whenever year changes

**Testing**
Tested locally by executing `npm run`, below is the screenshot of updated experience

<img width="291" alt="Screen Shot 2019-10-27 at 1 02 25 PM" src="https://user-images.githubusercontent.com/16041515/67631333-bffac900-f8ba-11e9-9443-ed9d831bedf2.png">



